### PR TITLE
Add basic layout with grid component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import GridLayout from "../components/grid-layout";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,12 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <header>Header</header>
+        <main>
+          <GridLayout />
+          {children}
+        </main>
+        <footer>Footer</footer>
       </body>
     </html>
   );

--- a/src/components/grid-layout.tsx
+++ b/src/components/grid-layout.tsx
@@ -1,0 +1,9 @@
+export default function GridLayout() {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <div>Column 1</div>
+      <div>Column 2</div>
+      <div>Column 3</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new GridLayout component with three-column grid
- update root layout to include header, main with GridLayout, and footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68909738cc588321b297598df1b60e22