### PR TITLE
feat: support dynamic grid columns

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,11 @@ export default function RootLayout({
       >
         <header>Header</header>
         <main>
-          <GridLayout />
+          <GridLayout scrollable>
+            <div>Column 1</div>
+            <div>Column 2</div>
+            <div>Column 3</div>
+          </GridLayout>
           {children}
         </main>
         <footer>Footer</footer>

--- a/src/components/grid-layout.tsx
+++ b/src/components/grid-layout.tsx
@@ -1,9 +1,35 @@
-export default function GridLayout() {
+import React from "react";
+
+interface GridLayoutProps {
+  children: React.ReactNode;
+  scrollable?: boolean;
+  height?: string;
+}
+
+export default function GridLayout({
+  children,
+  scrollable = false,
+  height = "100vh",
+}: GridLayoutProps) {
+  const childArray = React.Children.toArray(children);
+  const columnCount = Math.max(childArray.length, 1);
+
   return (
-    <div className="grid grid-cols-3 gap-4">
-      <div>Column 1</div>
-      <div>Column 2</div>
-      <div>Column 3</div>
+    <div
+      className={`grid grid-cols-${columnCount} gap-4`}
+      style={{
+        height,
+        gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+      }}
+    >
+      {childArray.map((child, index) => (
+        <div
+          key={index}
+          className={scrollable ? "overflow-y-scroll" : undefined}
+        >
+          {child}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow `GridLayout` to render any number of columns based on children
- add `scrollable` and `height` options with default height of full viewport
- use new grid layout in root layout with sample columns

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt requires configuration and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68909b17f9e48321af18dce3d239e9c0