### PR TITLE
feat: add grid column component

### DIFF
--- a/src/components/grid-column.tsx
+++ b/src/components/grid-column.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+import {
+  PanelLeft,
+  PanelLeftClose,
+  PanelRight,
+  PanelRightClose,
+} from "./icons";
+
+interface GridColumnProps {
+  children: React.ReactNode;
+  hasToggler?: boolean;
+  title?: string;
+  actions?: React.ReactNode;
+  isLast?: boolean;
+}
+
+export default function GridColumn({
+  children,
+  hasToggler = false,
+  title,
+  actions,
+  isLast = false,
+}: GridColumnProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const headerHeight = (actions ? 24 : 0) + (title ? 24 : 0);
+  const contentHeight = `calc(100% - ${headerHeight}px)`;
+
+  const handleToggle = () => setCollapsed(!collapsed);
+
+  const Icon = isLast
+    ? collapsed
+      ? PanelRight
+      : PanelRightClose
+    : collapsed
+    ? PanelLeft
+    : PanelLeftClose;
+
+  return (
+    <div className="relative flex h-full flex-col">
+      {hasToggler && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleToggle}
+          className={`absolute top-0 ${isLast ? "-left-3" : "-right-3"}`}
+        >
+          <Icon className="h-4 w-4" />
+        </Button>
+      )}
+      {!collapsed && (
+        <>
+          {actions && <div className="h-6">{actions}</div>}
+          {title && (
+            <div className="h-6 font-bold whitespace-nowrap">{title}</div>
+          )}
+          <div className="overflow-y-auto" style={{ height: contentHeight }}>
+            {children}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/grid-layout.tsx
+++ b/src/components/grid-layout.tsx
@@ -2,34 +2,31 @@ import React from "react";
 
 interface GridLayoutProps {
   children: React.ReactNode;
-  scrollable?: boolean;
   height?: string;
 }
 
 export default function GridLayout({
   children,
-  scrollable = false,
   height = "100vh",
 }: GridLayoutProps) {
-  const childArray = React.Children.toArray(children);
+  const childArray = React.Children.toArray(children) as React.ReactElement[];
   const columnCount = Math.max(childArray.length, 1);
 
   return (
     <div
-      className={`grid grid-cols-${columnCount} gap-4`}
+      className={`grid gap-4`}
       style={{
         height,
         gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
       }}
     >
-      {childArray.map((child, index) => (
-        <div
-          key={index}
-          className={scrollable ? "overflow-y-scroll" : undefined}
-        >
-          {child}
-        </div>
-      ))}
+      {childArray.map((child, index) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, {
+              isLast: index === columnCount - 1,
+            })
+          : child
+      )}
     </div>
   );
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+const baseProps = {
+  xmlns: "http://www.w3.org/2000/svg",
+  width: 24,
+  height: 24,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+export const PanelLeft = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg {...baseProps} {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="9" y1="3" x2="9" y2="21" />
+  </svg>
+);
+
+export const PanelLeftClose = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg {...baseProps} {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="9" y1="3" x2="9" y2="21" />
+    <path d="M15 9l-3 3 3 3" />
+  </svg>
+);
+
+export const PanelRight = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg {...baseProps} {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="15" y1="3" x2="15" y2="21" />
+  </svg>
+);
+
+export const PanelRightClose = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg {...baseProps} {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="15" y1="3" x2="15" y2="21" />
+    <path d="M9 9l3 3-3 3" />
+  </svg>
+);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "ghost";
+  size?: "default" | "icon";
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = "", variant = "default", size = "default", ...props }, ref) => {
+    const base =
+      "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+    const variants: Record<string, string> = {
+      default: "bg-primary text-primary-foreground hover:bg-primary/90",
+      ghost: "hover:bg-accent hover:text-accent-foreground",
+    };
+    const sizes: Record<string, string> = {
+      default: "h-10 px-4 py-2",
+      icon: "h-6 w-6",
+    };
+    return (
+      <button
+        ref={ref}
+        className={`${base} ${variants[variant]} ${sizes[size]} ${className}`}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";


### PR DESCRIPTION
## Summary
- add GridColumn component supporting headers and optional toggle button
- provide Button and panel icons to support grid columns
- update GridLayout to use GridColumn children and mark last column for left toggle

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6890a247b6ec8321b7c103c8c42dc508