### PR TITLE
Add column visibility hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.4.5"
+    "next": "15.4.5",
+    "ahooks": "^3.8.2"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/components/grid-column.tsx
+++ b/src/components/grid-column.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Button } from "./ui/button";
 import {
   PanelLeft,
@@ -13,6 +13,8 @@ interface GridColumnProps {
   title?: string;
   actions?: React.ReactNode;
   isLast?: boolean;
+  collapsed?: boolean;
+  onToggle?: () => void;
 }
 
 export default function GridColumn({
@@ -21,13 +23,11 @@ export default function GridColumn({
   title,
   actions,
   isLast = false,
+  collapsed = false,
+  onToggle,
 }: GridColumnProps) {
-  const [collapsed, setCollapsed] = useState(false);
-
   const headerHeight = (actions ? 24 : 0) + (title ? 24 : 0);
   const contentHeight = `calc(100% - ${headerHeight}px)`;
-
-  const handleToggle = () => setCollapsed(!collapsed);
 
   const Icon = isLast
     ? collapsed
@@ -43,7 +43,7 @@ export default function GridColumn({
         <Button
           variant="ghost"
           size="icon"
-          onClick={handleToggle}
+          onClick={onToggle}
           className={`absolute top-0 ${isLast ? "-left-3" : "-right-3"}`}
         >
           <Icon className="h-4 w-4" />

--- a/src/components/grid-layout.tsx
+++ b/src/components/grid-layout.tsx
@@ -1,16 +1,21 @@
 import React from "react";
+import useGridColumnVisibility from "../hooks/use-grid-column-visibility";
 
 interface GridLayoutProps {
   children: React.ReactNode;
   height?: string;
+  name: string;
+  scrollable?: boolean; // allow extra prop used elsewhere
 }
 
 export default function GridLayout({
   children,
+  name,
   height = "100vh",
 }: GridLayoutProps) {
   const childArray = React.Children.toArray(children) as React.ReactElement[];
   const columnCount = Math.max(childArray.length, 1);
+  const [visibility, toggle] = useGridColumnVisibility(name, columnCount);
 
   return (
     <div
@@ -24,6 +29,8 @@ export default function GridLayout({
         React.isValidElement(child)
           ? React.cloneElement(child, {
               isLast: index === columnCount - 1,
+              collapsed: !visibility[index],
+              onToggle: () => toggle(index),
             })
           : child
       )}

--- a/src/hooks/use-grid-column-visibility.ts
+++ b/src/hooks/use-grid-column-visibility.ts
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useLocalStorageState } from "ahooks";
+
+export default function useGridColumnVisibility(
+  name: string,
+  columnCount: number
+) {
+  const defaultValue = Array(columnCount).fill(true);
+
+  const [visibility = defaultValue, setVisibility] = useLocalStorageState<
+    boolean[]
+  >(`grid-visibility:${name}`, {
+    defaultValue,
+  });
+
+  const toggle = useCallback(
+    (index: number) => {
+      setVisibility((prev = defaultValue) => {
+        const next = [
+          ...prev,
+          ...Array(Math.max(columnCount - prev.length, 0)).fill(true),
+        ].slice(0, columnCount);
+        next[index] = !next[index];
+        return next;
+      });
+    },
+    [columnCount, setVisibility, defaultValue]
+  );
+
+  return [visibility, toggle] as const;
+}


### PR DESCRIPTION
## Summary
- add `ahooks` dependency
- introduce `useGridColumnVisibility` hook to persist column visibility
- wire `GridLayout` and `GridColumn` to use centralized visibility state

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6890a63c25b8832182b63f312799acd9