### PR TITLE
feat: add grid column resizing

### DIFF
--- a/src/components/grid-column.tsx
+++ b/src/components/grid-column.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Button } from "./ui/button";
 import {
@@ -9,7 +11,7 @@ import {
 
 const HEADER_BLOCK_HEIGHT = 44;
 
-interface GridColumnProps {
+export interface GridColumnProps {
   children: React.ReactNode;
   hasToggler?: boolean;
   title?: string;
@@ -17,77 +19,84 @@ interface GridColumnProps {
   isLast?: boolean;
   collapsed?: boolean;
   onToggle?: () => void;
+  className?: string;
 }
 
-export default function GridColumn({
-  children,
-  hasToggler = false,
-  title,
-  actions,
-  isLast = false,
-  collapsed = false,
-  onToggle,
-}: GridColumnProps) {
-  const headerHeight =
-    (actions ? HEADER_BLOCK_HEIGHT : 0) +
-    (title ? HEADER_BLOCK_HEIGHT : 0);
-  const contentHeight = `calc(100% - ${headerHeight}px)`;
+const GridColumn = React.forwardRef<HTMLDivElement, GridColumnProps>(
+  function GridColumn(
+    {
+      children,
+      hasToggler = false,
+      title,
+      actions,
+      isLast = false,
+      collapsed = false,
+      onToggle,
+      className = "",
+    },
+    ref
+  ) {
+    const headerHeight =
+      (actions ? HEADER_BLOCK_HEIGHT : 0) +
+      (title ? HEADER_BLOCK_HEIGHT : 0);
+    const contentHeight = `calc(100% - ${headerHeight}px)`;
 
-  const Icon = isLast
-    ? collapsed
-      ? PanelRight
-      : PanelRightClose
-    : collapsed
-    ? PanelLeft
-    : PanelLeftClose;
+    let Icon;
+    if (isLast) {
+      Icon = collapsed ? PanelRight : PanelRightClose;
+    } else {
+      Icon = collapsed ? PanelLeft : PanelLeftClose;
+    }
 
-  const togglePosition = collapsed
-    ? isLast
-      ? "left-0"
-      : "right-0"
-    : isLast
-    ? "-left-3"
-    : "-right-3";
+    let togglePosition;
+    if (collapsed) {
+      togglePosition = isLast ? "left-0" : "right-0";
+    } else {
+      togglePosition = isLast ? "-left-3" : "-right-3";
+    }
 
-  return (
-    <div className="relative flex h-full flex-col">
-      {hasToggler && (
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onToggle}
-          className={`absolute top-0 ${togglePosition}`}
-        >
-          <Icon className="h-4 w-4" />
-        </Button>
-      )}
-      {collapsed ? (
-        title ? (
-          <div
-            className="flex flex-1 items-center justify-center text-sm"
-            style={{ writingMode: "vertical-rl" }}
+    return (
+      <div ref={ref} className={`relative flex h-full flex-col ${className}`}>
+        {hasToggler && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onToggle}
+            className={`absolute top-0 ${togglePosition}`}
           >
-            {title}
-          </div>
-        ) : null
-      ) : (
-        <>
-          {actions && (
-            <div style={{ height: HEADER_BLOCK_HEIGHT }}>{actions}</div>
-          )}
-          {title && (
+            <Icon className="h-4 w-4" />
+          </Button>
+        )}
+        {collapsed ? (
+          title ? (
             <div
-              className="font-bold whitespace-nowrap"
-              style={{ height: HEADER_BLOCK_HEIGHT }}
+              className="flex flex-1 items-center justify-center text-sm"
+              style={{ writingMode: "vertical-rl" }}
             >
               {title}
             </div>
-          )}
-          <div className="overflow-y-auto" style={{ height: contentHeight }}>
-            {children}
-          </div>
-        </>
-      )}
-    </div>
-  );
-}
+          ) : null
+        ) : (
+          <>
+            {actions && (
+              <div style={{ height: HEADER_BLOCK_HEIGHT }}>{actions}</div>
+            )}
+            {title && (
+              <div
+                className="font-bold whitespace-nowrap"
+                style={{ height: HEADER_BLOCK_HEIGHT }}
+              >
+                {title}
+              </div>
+            )}
+            <div className="overflow-y-auto" style={{ height: contentHeight }}>
+              {children}
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+);
+
+export default GridColumn;

--- a/src/components/grid-layout.tsx
+++ b/src/components/grid-layout.tsx
@@ -1,8 +1,17 @@
-import React from "react";
+"use client";
+
+import React, { useRef } from "react";
 import useGridColumnVisibility from "../hooks/use-grid-column-visibility";
+import useGridColumnResizing from "../hooks/use-grid-column-resizing";
+import type GridColumn, { GridColumnProps } from "./grid-column";
 
 interface GridLayoutProps {
-  children: React.ReactNode;
+  children: [
+    React.ReactElement<GridColumnProps, typeof GridColumn>,
+    React.ReactElement<GridColumnProps, typeof GridColumn>,
+    React.ReactElement<GridColumnProps, typeof GridColumn>,
+    ...React.ReactElement<GridColumnProps, typeof GridColumn>[],
+  ];
   height?: string;
   name: string;
   scrollable?: boolean; // allow extra prop used elsewhere
@@ -13,27 +22,64 @@ export default function GridLayout({
   name,
   height = "100vh",
 }: GridLayoutProps) {
-  const childArray = React.Children.toArray(children) as React.ReactElement[];
-  const columnCount = Math.max(childArray.length, 1);
+  const childArray = React.Children.toArray(
+    children
+  ) as React.ReactElement<GridColumnProps, typeof GridColumn>[];
+  const columnCount = childArray.length;
+  if (columnCount < 3) {
+    throw new Error("GridLayout requires at least three GridColumn children");
+  }
   const [visibility, toggle] = useGridColumnVisibility(name, columnCount);
+  const [widths, startResize] = useGridColumnResizing(name, columnCount);
+  const columnRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const templateColumns = widths
+    .map((w) => (w ? `${w}px` : "1fr"))
+    .slice(0, columnCount)
+    .join(" ");
+
+  function renderResizer(index: number) {
+    if (index === columnCount - 1) {
+      return null;
+    }
+    return (
+      <div
+        className="absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize bg-transparent hover:bg-gray-300"
+        onMouseDown={(e) => {
+          const startWidth =
+            columnRefs.current[index]?.getBoundingClientRect().width || 0;
+          startResize(index, startWidth, e);
+        }}
+      />
+    );
+  }
 
   return (
     <div
       className={`grid gap-4`}
       style={{
         height,
-        gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+        gridTemplateColumns: templateColumns,
       }}
     >
-      {childArray.map((child, index) =>
-        React.isValidElement(child)
-          ? React.cloneElement(child, {
-              isLast: index === columnCount - 1,
-              collapsed: !visibility[index],
-              onToggle: () => toggle(index),
-            })
-          : child
-      )}
+      {childArray.map((child, index) => {
+        const isLast = index === columnCount - 1;
+        return React.cloneElement(
+          child,
+          {
+            key: index,
+            ref: (el: HTMLDivElement | null) => (columnRefs.current[index] = el),
+            className: `${child.props.className ?? ""} relative h-full`,
+            isLast,
+            collapsed: !visibility[index],
+            onToggle: () => toggle(index),
+          },
+          <>
+            {child.props.children}
+            {renderResizer(index)}
+          </>
+        );
+      })}
     </div>
   );
 }

--- a/src/hooks/use-grid-column-resizing.ts
+++ b/src/hooks/use-grid-column-resizing.ts
@@ -1,0 +1,47 @@
+import React, { useCallback } from "react";
+import { useLocalStorageState } from "ahooks";
+
+const MIN_COLUMN_WIDTH = 200;
+
+export default function useGridColumnResizing(
+  name: string,
+  columnCount: number
+) {
+  const defaultValue = Array(columnCount).fill(0);
+
+  const [sizes = defaultValue, setSizes] = useLocalStorageState<number[]>(
+    `grid-sizes:${name}`,
+    { defaultValue }
+  );
+
+  const startResize = useCallback(
+    (index: number, startWidth: number, startEvent: React.MouseEvent) => {
+      const startX = startEvent.clientX;
+
+      function onMouseMove(e: MouseEvent) {
+        const delta = e.clientX - startX;
+        const newWidth = Math.max(MIN_COLUMN_WIDTH, startWidth + delta);
+        setSizes((prev = defaultValue) => {
+          const next = [
+            ...prev,
+            ...Array(Math.max(columnCount - prev.length, 0)).fill(0),
+          ].slice(0, columnCount);
+          next[index] = newWidth;
+          return next;
+        });
+      }
+
+      function onMouseUp() {
+        window.removeEventListener("mousemove", onMouseMove);
+        window.removeEventListener("mouseup", onMouseUp);
+      }
+
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", onMouseUp);
+    },
+    [setSizes, columnCount, defaultValue]
+  );
+
+  return [sizes, startResize] as const;
+}
+


### PR DESCRIPTION
## Summary
- allow resizing grid columns with persistent width
- store resized widths in local storage
- ensure GridLayout receives at least three GridColumn children and simplify icon/toggler logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6890af9469c8832193ccb452f56a0547