### PR TITLE
Fix grid column resizing to adjust only adjacent column

### DIFF
--- a/src/components/grid-layout/grid-layout.tsx
+++ b/src/components/grid-layout/grid-layout.tsx
@@ -58,10 +58,13 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
             onToggle: () => toggle(index),
             showResizer: !isLast,
             onResizeStart: (e: React.MouseEvent) => {
-              const startWidth = columnRefs.current[index]?.getBoundingClientRect().width || 0;
-              startResize(index, startWidth, e);
+              const startWidth =
+                columnRefs.current[index]?.getBoundingClientRect().width || 0;
+              const nextStartWidth =
+                columnRefs.current[index + 1]?.getBoundingClientRect().width || 0;
+              startResize(index, startWidth, nextStartWidth, e);
             },
-          },
+          } as unknown as React.ComponentProps<typeof GridColumn>,
           child.props.children
         );
       })}

--- a/src/components/grid-layout/hooks/use-grid-column-resizing.ts
+++ b/src/components/grid-layout/hooks/use-grid-column-resizing.ts
@@ -15,18 +15,40 @@ export default function useGridColumnResizing(
   );
 
   const startResize = useCallback(
-    (index: number, startWidth: number, startEvent: React.MouseEvent) => {
+    (
+      index: number,
+      startWidth: number,
+      nextStartWidth: number,
+      startEvent: React.MouseEvent
+    ) => {
       const startX = startEvent.clientX;
 
       function onMouseMove(e: MouseEvent) {
-        const delta = e.clientX - startX;
-        const newWidth = Math.max(MIN_COLUMN_WIDTH, startWidth + delta);
+        let delta = e.clientX - startX;
+        let newWidth = startWidth + delta;
+        let newNextWidth = nextStartWidth - delta;
+
+        if (newWidth < MIN_COLUMN_WIDTH) {
+          newWidth = MIN_COLUMN_WIDTH;
+          delta = newWidth - startWidth;
+          newNextWidth = nextStartWidth - delta;
+        }
+
+        if (newNextWidth < MIN_COLUMN_WIDTH) {
+          newNextWidth = MIN_COLUMN_WIDTH;
+          delta = nextStartWidth - newNextWidth;
+          newWidth = startWidth + delta;
+        }
+
         setSizes((prev = defaultValue) => {
           const next = [
             ...prev,
             ...Array(Math.max(columnCount - prev.length, 0)).fill(0),
           ].slice(0, columnCount);
           next[index] = newWidth;
+          if (index + 1 < columnCount) {
+            next[index + 1] = newNextWidth;
+          }
           return next;
         });
       }


### PR DESCRIPTION
## Summary
- Update `useGridColumnResizing` to distribute width delta between the resized column and its neighbor
- Pass next column width to resize hook when starting drag

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6890d591a7d883218028af1e28ab99bd