### PR TITLE
Handle collapsed grid columns

### DIFF
--- a/src/components/grid-layout/grid-column.tsx
+++ b/src/components/grid-layout/grid-column.tsx
@@ -19,6 +19,7 @@ export interface GridColumnProps {
   collapsed?: boolean;
   onToggle?: () => void;
   className?: string;
+  isResizing?: boolean;
 }
 
 export const GridColumn = React.forwardRef<HTMLDivElement, GridColumnProps>(function GridColumn(
@@ -34,6 +35,7 @@ export const GridColumn = React.forwardRef<HTMLDivElement, GridColumnProps>(func
     className = "",
     showResizer = false,
     onResizeStart,
+    isResizing = false,
   },
   ref
 ) {
@@ -52,7 +54,15 @@ export const GridColumn = React.forwardRef<HTMLDivElement, GridColumnProps>(func
   const borderClass = isFirst ? "" : "border-l border-neutral-300";
 
   return (
-    <div ref={ref} className={`relative flex h-full flex-col ${borderClass} ${className}`}>
+    <div
+      ref={ref}
+      className={cn(
+        "relative flex h-full flex-col",
+        !isResizing && "transition-[width] duration-300",
+        borderClass,
+        className
+      )}
+    >
       {hasToggler && (
         <Button
           variant="ghost"

--- a/src/components/grid-layout/grid-layout.tsx
+++ b/src/components/grid-layout/grid-layout.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from "react";
 import useGridColumnVisibility from "./hooks/use-grid-column-visibility";
 import useGridColumnResizing from "./hooks/use-grid-column-resizing";
 import type { GridColumn, GridColumnProps } from "./grid-column";
+import { cn } from "@/utils";
 
 interface GridLayoutProps {
   children: [
@@ -27,7 +28,11 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
     throw new Error("GridLayout requires at least three GridColumn children");
   }
   const [visibility, toggle] = useGridColumnVisibility(name, columnCount);
-  const [widths, startResize] = useGridColumnResizing(name, columnCount);
+  const [widths, startResize, isResizing] = useGridColumnResizing(
+    name,
+    columnCount,
+    visibility
+  );
   const columnRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const templateColumns = widths
@@ -37,7 +42,10 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
 
   return (
     <div
-      className="grid w-full"
+      className={cn(
+        "grid w-full",
+        !isResizing && "transition-[grid-template-columns] duration-300"
+      )}
       style={{
         height,
         gridTemplateColumns: templateColumns,
@@ -56,7 +64,8 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
             isFirst,
             collapsed: !visibility[index],
             onToggle: () => toggle(index),
-            showResizer: !isLast,
+            showResizer: !isLast && visibility[index] && visibility[index + 1],
+            isResizing,
             onResizeStart: (e: React.MouseEvent) => {
               const startWidth =
                 columnRefs.current[index]?.getBoundingClientRect().width || 0;

--- a/src/components/grid-layout/hooks/use-grid-column-resizing.ts
+++ b/src/components/grid-layout/hooks/use-grid-column-resizing.ts
@@ -1,34 +1,76 @@
 "use client";
 
-import React, { useCallback } from "react";
+import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useLocalStorageState } from "ahooks";
 
 const MIN_COLUMN_WIDTH = 200;
+const COLLAPSED_WIDTH = 44;
 
-export default function useGridColumnResizing(name: string, columnCount: number) {
-  const defaultValue = Array(columnCount).fill(window.innerWidth / columnCount);
+export default function useGridColumnResizing(
+  name: string,
+  columnCount: number,
+  visibility: boolean[]
+) {
+  const collapsedCount = visibility.filter((v) => !v).length;
+  const availableWidth =
+    columnCount - collapsedCount > 0
+      ? (window.innerWidth - COLLAPSED_WIDTH * collapsedCount) /
+        (columnCount - collapsedCount)
+      : 0;
+  const defaultValue = Array(columnCount).fill(availableWidth);
+  visibility.forEach((v, i) => {
+    if (!v) defaultValue[i] = COLLAPSED_WIDTH;
+  });
 
   const [sizes = defaultValue, setSizes] = useLocalStorageState<number[]>(`grid-sizes:${name}`, {
     defaultValue,
   });
 
+  // Skip recalculation on mount to preserve widths from localStorage
+  const initialized = useRef(false);
+  useLayoutEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true;
+      return;
+    }
+    setSizes(() => {
+      const collapsed = visibility.filter((v) => !v).length;
+      const visibleCount = columnCount - collapsed;
+      const visibleWidth =
+        visibleCount > 0
+          ? (window.innerWidth - COLLAPSED_WIDTH * collapsed) / visibleCount
+          : 0;
+      const next = Array(columnCount).fill(visibleWidth);
+      visibility.forEach((v, i) => {
+        if (!v) next[i] = COLLAPSED_WIDTH;
+      });
+      return next;
+    });
+  }, [visibility, columnCount, setSizes]);
+
+  const [isResizing, setIsResizing] = useState(false);
+
   const startResize = useCallback(
     (index: number, startWidth: number, nextStartWidth: number, startEvent: React.MouseEvent) => {
       const startX = startEvent.clientX;
+      setIsResizing(true);
 
       function onMouseMove(e: MouseEvent) {
         let delta = e.clientX - startX;
         let newWidth = startWidth + delta;
         let newNextWidth = nextStartWidth - delta;
 
-        if (newWidth < MIN_COLUMN_WIDTH) {
-          newWidth = MIN_COLUMN_WIDTH;
+        const minCurrent = visibility[index] ? MIN_COLUMN_WIDTH : COLLAPSED_WIDTH;
+        const minNext = visibility[index + 1] ? MIN_COLUMN_WIDTH : COLLAPSED_WIDTH;
+
+        if (newWidth < minCurrent) {
+          newWidth = minCurrent;
           delta = newWidth - startWidth;
           newNextWidth = nextStartWidth - delta;
         }
 
-        if (newNextWidth < MIN_COLUMN_WIDTH) {
-          newNextWidth = MIN_COLUMN_WIDTH;
+        if (newNextWidth < minNext) {
+          newNextWidth = minNext;
           delta = nextStartWidth - newNextWidth;
           newWidth = startWidth + delta;
         }
@@ -49,13 +91,14 @@ export default function useGridColumnResizing(name: string, columnCount: number)
       function onMouseUp() {
         window.removeEventListener("mousemove", onMouseMove);
         window.removeEventListener("mouseup", onMouseUp);
+        setIsResizing(false);
       }
 
       window.addEventListener("mousemove", onMouseMove);
       window.addEventListener("mouseup", onMouseUp);
     },
-    [setSizes, columnCount, defaultValue]
+    [setSizes, columnCount, defaultValue, visibility]
   );
 
-  return [sizes, startResize] as const;
+  return [sizes, startResize, isResizing] as const;
 }


### PR DESCRIPTION
## Summary
- Add fixed 44px size for collapsed grid columns and recalc widths when visibility changes
- Hide resizers for collapsed columns and animate grid-template changes for smooth transitions
- Apply width transitions to grid columns only when collapsing, keeping manual resizes immediate
- Use `cn` utility for clearer grid column container classes
- Recalculate column widths in a `useLayoutEffect` to update layout before paint
- Preserve saved column widths from local storage on reload

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68910178310c83218e366a3767a3bb32