### PR TITLE
feat: preserve column widths on collapse

### DIFF
--- a/src/components/grid-layout/hooks/use-grid-column-resizing.ts
+++ b/src/components/grid-layout/hooks/use-grid-column-resizing.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useLocalStorageState } from "ahooks";
 
 const MIN_COLUMN_WIDTH = 200;
@@ -11,47 +11,53 @@ export default function useGridColumnResizing(
   columnCount: number,
   visibility: boolean[]
 ) {
+  // Determine how much horizontal space remains after accounting for collapsed columns
   const collapsedCount = visibility.filter((v) => !v).length;
   const availableWidth =
     columnCount - collapsedCount > 0
       ? (window.innerWidth - COLLAPSED_WIDTH * collapsedCount) /
         (columnCount - collapsedCount)
       : 0;
+  // Default widths for each column, used on first render or when storage is empty
   const defaultValue = Array(columnCount).fill(availableWidth);
-  visibility.forEach((v, i) => {
-    if (!v) defaultValue[i] = COLLAPSED_WIDTH;
-  });
 
-  const [sizes = defaultValue, setSizes] = useLocalStorageState<number[]>(`grid-sizes:${name}`, {
-    defaultValue,
-  });
-
-  // Skip recalculation on mount to preserve widths from localStorage
-  const initialized = useRef(false);
-  useLayoutEffect(() => {
-    if (!initialized.current) {
-      initialized.current = true;
-      return;
+  const [storedSizes = defaultValue, setStoredSizes] = useLocalStorageState<number[]>(
+    `grid-sizes:${name}`,
+    {
+      defaultValue,
     }
-    setSizes(() => {
-      const collapsed = visibility.filter((v) => !v).length;
-      const visibleCount = columnCount - collapsed;
-      const visibleWidth =
-        visibleCount > 0
-          ? (window.innerWidth - COLLAPSED_WIDTH * collapsed) / visibleCount
-          : 0;
-      const next = Array(columnCount).fill(visibleWidth);
-      visibility.forEach((v, i) => {
-        if (!v) next[i] = COLLAPSED_WIDTH;
-      });
+  );
+  // Active widths of the grid: collapsed columns use COLLAPSED_WIDTH, others use stored sizes
+  const [sizes, setSizes] = useState<number[]>(
+    storedSizes.map((w, i) => (visibility[i] ? w : COLLAPSED_WIDTH))
+  );
+
+  // Keep active widths in sync when visibility or stored sizes change
+  useEffect(() => {
+    setSizes(storedSizes.map((w, i) => (visibility[i] ? w : COLLAPSED_WIDTH)));
+  }, [storedSizes, visibility]);
+
+  // Ensure the stored sizes array always matches the current column count
+  useEffect(() => {
+    setStoredSizes((prev = defaultValue) => {
+      const next = [
+        ...prev,
+        ...Array(Math.max(columnCount - prev.length, 0)).fill(availableWidth),
+      ].slice(0, columnCount);
       return next;
     });
-  }, [visibility, columnCount, setSizes]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columnCount, setStoredSizes]);
 
   const [isResizing, setIsResizing] = useState(false);
 
   const startResize = useCallback(
-    (index: number, startWidth: number, nextStartWidth: number, startEvent: React.MouseEvent) => {
+    (
+      index: number,
+      startWidth: number,
+      nextStartWidth: number,
+      startEvent: React.MouseEvent
+    ) => {
       const startX = startEvent.clientX;
       setIsResizing(true);
 
@@ -60,26 +66,43 @@ export default function useGridColumnResizing(
         let newWidth = startWidth + delta;
         let newNextWidth = nextStartWidth - delta;
 
+        // Determine the minimum width each column is allowed to shrink to
         const minCurrent = visibility[index] ? MIN_COLUMN_WIDTH : COLLAPSED_WIDTH;
         const minNext = visibility[index + 1] ? MIN_COLUMN_WIDTH : COLLAPSED_WIDTH;
 
+        // Ensure the current column respects its minimum width
         if (newWidth < minCurrent) {
           newWidth = minCurrent;
           delta = newWidth - startWidth;
           newNextWidth = nextStartWidth - delta;
         }
 
+        // Ensure the adjacent column also respects its minimum width
         if (newNextWidth < minNext) {
           newNextWidth = minNext;
           delta = nextStartWidth - newNextWidth;
           newWidth = startWidth + delta;
         }
 
+        // Persist updated sizes in local storage so they survive toggles
+        setStoredSizes((prev = defaultValue) => {
+          const next = [
+            ...prev,
+            ...Array(Math.max(columnCount - prev.length, 0)).fill(0),
+          ].slice(0, columnCount);
+          next[index] = newWidth;
+          if (index + 1 < columnCount) {
+            next[index + 1] = newNextWidth;
+          }
+          return next;
+        });
+
+        // Reflect the drag in the current render state
         setSizes((prev = defaultValue) => {
-          const next = [...prev, ...Array(Math.max(columnCount - prev.length, 0)).fill(0)].slice(
-            0,
-            columnCount
-          );
+          const next = [
+            ...prev,
+            ...Array(Math.max(columnCount - prev.length, 0)).fill(0),
+          ].slice(0, columnCount);
           next[index] = newWidth;
           if (index + 1 < columnCount) {
             next[index + 1] = newNextWidth;
@@ -97,7 +120,13 @@ export default function useGridColumnResizing(
       window.addEventListener("mousemove", onMouseMove);
       window.addEventListener("mouseup", onMouseUp);
     },
-    [setSizes, columnCount, defaultValue, visibility]
+    [
+      setStoredSizes,
+      setSizes,
+      columnCount,
+      defaultValue,
+      visibility,
+    ]
   );
 
   return [sizes, startResize, isResizing] as const;


### PR DESCRIPTION
## Summary
- keep user-defined column sizes when panels collapse
- update resize handler to sync persistent and active widths
- document resizing hook logic with explanatory comments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68910bed428083218db3974ba910c974