### PR TITLE
refactor grid column props

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
             Add new collection
           </Button>
         }
-        hasToggler
+        showToggler
       >
         <div className="space-y-3">
           <p className="text-sm">
@@ -31,7 +31,7 @@ export default function Home() {
         ipsum saepe culpa aperiam minima nobis reiciendis quibusdam, consectetur quasi officiis
         quaerat, pariatur et accusantium soluta totam mollitia?
       </GridColumn>
-      <GridColumn title="History" hasToggler>
+      <GridColumn title="History" showToggler>
         <p className="text-sm">
           Lorem ipsum dolor sit, amet consectetur adipisicing elit. Voluptas alias asperiores quam
           deleniti dolore dicta maiores eaque molestiae dolorum odio quod veritatis explicabo quis,

--- a/src/components/grid-layout/grid-column-base.tsx
+++ b/src/components/grid-layout/grid-column-base.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React from "react";
+import { PanelLeft, PanelLeftClose, PanelRight, PanelRightClose } from "lucide-react";
+import { Button } from "../ui/button";
+import { cn } from "@/utils";
+import type { GridColumnBaseProps } from "./types";
+
+const HEADER_BLOCK_HEIGHT = 48;
+const BORDER_COLOR = "border-neutral-300";
+
+export const GridColumnBase = React.forwardRef<HTMLDivElement, GridColumnBaseProps>(
+  function GridColumnBase(
+    {
+      children,
+      showToggler = false,
+      title,
+      actions,
+      isFirst = false,
+      isLast = false,
+      collapsed = false,
+      onToggle,
+      className = "",
+      showResizer = false,
+      onResizeStart,
+      isResizing = false,
+      showScroller = true,
+    },
+    ref
+  ) {
+    let Icon;
+    if (isLast) {
+      Icon = collapsed ? PanelRight : PanelRightClose;
+    } else {
+      Icon = collapsed ? PanelLeft : PanelLeftClose;
+    }
+
+    const togglePosition = isLast ? "left-3" : "right-3";
+
+    const borderClass = isFirst ? "" : `border-l ${BORDER_COLOR}`;
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "relative flex h-full min-h-0 flex-col",
+          !isResizing && "transition-[width] duration-300",
+          borderClass,
+          className
+        )}
+      >
+        {showToggler && (
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onToggle}
+            className={`border !${BORDER_COLOR} absolute top-3 ${togglePosition}`}
+          >
+            <Icon className="h-4 w-4" />
+          </Button>
+        )}
+        {showResizer && !collapsed && (
+          <div
+            className="absolute top-0 -right-0.5 z-10 h-full w-1 cursor-col-resize select-none bg-transparent hover:bg-gray-300"
+            onMouseDown={onResizeStart}
+          />
+        )}
+        {collapsed ? (
+          title ? (
+            <div
+              className="px-12 uppercase flex flex-1 items-center justify-start text-sm"
+              style={{ writingMode: "vertical-rl" }}
+            >
+              {title}
+            </div>
+          ) : null
+        ) : (
+          <>
+            {actions && (
+              <div className="p-3" style={{ height: HEADER_BLOCK_HEIGHT }}>
+                {actions}
+              </div>
+            )}
+            {title && (
+              <div
+                className={cn(
+                  "p-3 flex items-center font-semibold whitespace-nowrap text-lg border-b",
+                  BORDER_COLOR,
+                  {
+                    "indent-8": isLast,
+                  }
+                )}
+                style={{ height: HEADER_BLOCK_HEIGHT }}
+              >
+                {title}
+              </div>
+            )}
+            <div
+              className={cn(
+                "flex-1 p-3",
+                showScroller && "overflow-y-auto min-h-0"
+              )}
+            >
+              {children}
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+);

--- a/src/components/grid-layout/grid-column.tsx
+++ b/src/components/grid-layout/grid-column.tsx
@@ -1,124 +1,18 @@
 "use client";
 
 import React from "react";
-import { PanelLeft, PanelLeftClose, PanelRight, PanelRightClose } from "lucide-react";
-import { Button } from "../ui/button";
-import { cn } from "@/utils";
+import { GridColumnBase } from "./grid-column-base";
+import type { GridColumnPublicProps } from "./types";
 
-const HEADER_BLOCK_HEIGHT = 48;
-const BORDER_COLOR = "border-neutral-300";
+export type {
+  GridColumnPublicProps,
+  GridColumnInternalProps,
+  GridColumnBaseProps,
+} from "./types";
 
-export interface GridColumnProps {
-  showResizer?: boolean;
-  onResizeStart?: (e: React.MouseEvent) => void;
-  children: React.ReactNode;
-  hasToggler?: boolean;
-  title?: string;
-  actions?: React.ReactNode;
-  isFirst?: boolean;
-  isLast?: boolean;
-  collapsed?: boolean;
-  onToggle?: () => void;
-  className?: string;
-  isResizing?: boolean;
-  scrollable?: boolean;
-}
-
-export const GridColumn = React.forwardRef<HTMLDivElement, GridColumnProps>(function GridColumn(
-  {
-    children,
-    hasToggler = false,
-    title,
-    actions,
-    isFirst = false,
-    isLast = false,
-    collapsed = false,
-    onToggle,
-    className = "",
-    showResizer = false,
-    onResizeStart,
-    isResizing = false,
-    scrollable = true,
-  },
+export const GridColumn = React.forwardRef<HTMLDivElement, GridColumnPublicProps>(function GridColumn(
+  props,
   ref
 ) {
-  let Icon;
-  if (isLast) {
-    Icon = collapsed ? PanelRight : PanelRightClose;
-  } else {
-    Icon = collapsed ? PanelLeft : PanelLeftClose;
-  }
-
-  const togglePosition = isLast ? "left-3" : "right-3";
-
-  const borderClass = isFirst ? "" : `border-l ${BORDER_COLOR}`;
-
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "relative flex h-full min-h-0 flex-col",
-        !isResizing && "transition-[width] duration-300",
-        borderClass,
-        className
-      )}
-    >
-      {hasToggler && (
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={onToggle}
-          className={`border !${BORDER_COLOR} absolute top-3 ${togglePosition}`}
-        >
-          <Icon className="h-4 w-4" />
-        </Button>
-      )}
-      {showResizer && !collapsed && (
-        <div
-          className="absolute top-0 -right-0.5 z-10 h-full w-1 cursor-col-resize select-none bg-transparent hover:bg-gray-300"
-          onMouseDown={onResizeStart}
-        />
-      )}
-      {collapsed ? (
-        title ? (
-          <div
-            className="px-12 uppercase flex flex-1 items-center justify-start text-sm"
-            style={{ writingMode: "vertical-rl" }}
-          >
-            {title}
-          </div>
-        ) : null
-      ) : (
-        <>
-          {actions && (
-            <div className="p-3" style={{ height: HEADER_BLOCK_HEIGHT }}>
-              {actions}
-            </div>
-          )}
-          {title && (
-            <div
-              className={cn(
-                "p-3 flex items-center font-semibold whitespace-nowrap text-lg border-b",
-                BORDER_COLOR,
-                {
-                  "indent-8": isLast,
-                }
-              )}
-              style={{ height: HEADER_BLOCK_HEIGHT }}
-            >
-              {title}
-            </div>
-          )}
-          <div
-            className={cn(
-              "flex-1 p-3",
-              scrollable && "overflow-y-auto min-h-0"
-            )}
-          >
-            {children}
-          </div>
-        </>
-      )}
-    </div>
-  );
+  return <GridColumnBase ref={ref} {...props} />;
 });

--- a/src/components/grid-layout/types.ts
+++ b/src/components/grid-layout/types.ts
@@ -1,0 +1,27 @@
+export interface GridColumnPublicProps {
+  /** Display the column resize handle */
+  showResizer?: boolean;
+  /** Show toggle button */
+  showToggler?: boolean;
+  /** Enable vertical scrolling within the column */
+  showScroller?: boolean;
+  /** Optional title displayed in the column header */
+  title?: string;
+  /** Optional action elements rendered in the header */
+  actions?: React.ReactNode;
+  /** Additional class names */
+  className?: string;
+  /** Column content */
+  children: React.ReactNode;
+}
+
+export interface GridColumnInternalProps {
+  onResizeStart?: (e: React.MouseEvent) => void;
+  isFirst?: boolean;
+  isLast?: boolean;
+  collapsed?: boolean;
+  onToggle?: () => void;
+  isResizing?: boolean;
+}
+
+export type GridColumnBaseProps = GridColumnPublicProps & GridColumnInternalProps;


### PR DESCRIPTION
## Summary
- separate internal/public props using new `GridColumnBase`
- simplify `GridColumn` to wrap `GridColumnBase`
- update prop names (e.g., `showToggler`, `showScroller`) and adjust `GridLayout`
- rename `grid-column.types.ts` to `types.ts`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68923eca9354832196feb5001091cc18