### PR TITLE
feat: add tabs panel to grid columns

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ export default function Home() {
     <GridLayout name="test-layout" scrollable height="calc(100vh - 80px)">
       <GridColumn
         title="Collection"
+        tabs={<div className="text-sm">Tabs</div>}
         actions={
           <Button variant="outline" size="small">
             Add new collection

--- a/src/components/grid-layout/grid-column-base.tsx
+++ b/src/components/grid-layout/grid-column-base.tsx
@@ -15,6 +15,7 @@ export const GridColumnBase = React.forwardRef<HTMLDivElement, GridColumnBasePro
       children,
       showToggler = false,
       title,
+      tabs,
       actions,
       isFirst = false,
       isLast = false,
@@ -76,6 +77,11 @@ export const GridColumnBase = React.forwardRef<HTMLDivElement, GridColumnBasePro
           ) : null
         ) : (
           <>
+            {tabs && (
+              <div className="p-3" style={{ height: HEADER_BLOCK_HEIGHT }}>
+                {tabs}
+              </div>
+            )}
             {actions && (
               <div className="p-3" style={{ height: HEADER_BLOCK_HEIGHT }}>
                 {actions}

--- a/src/components/grid-layout/types.ts
+++ b/src/components/grid-layout/types.ts
@@ -7,6 +7,8 @@ export interface GridColumnPublicProps {
   showScroller?: boolean;
   /** Optional title displayed in the column header */
   title?: string;
+  /** Optional tabs elements rendered above actions */
+  tabs?: React.ReactNode;
   /** Optional action elements rendered in the header */
   actions?: React.ReactNode;
   /** Additional class names */


### PR DESCRIPTION
## Summary
- add optional `tabs` panel above actions and title in grid column
- extend grid column props with new `tabs` field
- demonstrate `tabs` usage on example page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689244eecfec83218d731e83c14470ac