### PR TITLE
feat: add layout-level GridTabs slot

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import {
   GridLayout,
   GridColumnTitle,
   GridColumnActions,
-  GridColumnTabs,
+  GridTabs,
 } from "@ui/components/grid-layout";
 import { Button } from "@ui/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@ui/components/ui/tabs";
@@ -18,6 +18,12 @@ export default function Home() {
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
       <GridLayout name="test-layout" scrollable height="calc(100vh - 8rem)">
+        <GridTabs start={2} end={4} height={48}>
+          <TabsList>
+            <TabsTrigger value="chat">Chat</TabsTrigger>
+            <TabsTrigger value="content">Content</TabsTrigger>
+          </TabsList>
+        </GridTabs>
         <GridColumn showToggler>
           <GridColumnTitle>Collection</GridColumnTitle>
           <GridColumnActions>
@@ -37,12 +43,6 @@ export default function Home() {
           </div>
         </GridColumn>
         <GridColumn className="bg-neutral-50">
-          <GridColumnTabs>
-            <TabsList>
-              <TabsTrigger value="chat">Chat</TabsTrigger>
-              <TabsTrigger value="content">Content</TabsTrigger>
-            </TabsList>
-          </GridColumnTabs>
           <TabsContent value="chat">
             <p className="text-sm">
               Neutron stars are so dense that a teaspoon of their material would weigh about six

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
       <GridLayout name="test-layout" scrollable height="calc(100vh - 8rem)">
-        <GridTabs start={2} end={4}>
+        <GridTabs start={3} end={4}>
           <TabsList>
             <TabsTrigger value="chat">Chat</TabsTrigger>
             <TabsTrigger value="content">Content</TabsTrigger>
@@ -42,20 +42,6 @@ export default function Home() {
             </p>
           </div>
         </GridColumn>
-        <GridColumn className="bg-neutral-50">
-          <TabsContent value="chat">
-            <p className="text-sm">
-              Neutron stars are so dense that a teaspoon of their material would weigh about six
-              billion tons on Earth.
-            </p>
-          </TabsContent>
-          <TabsContent value="content">
-            <p className="text-sm">
-              Jupiter's magnetic field is powerful enough to produce auroras larger than our entire
-              planet.
-            </p>
-          </TabsContent>
-        </GridColumn>
         <GridColumn showToggler>
           <TabsContent value="chat">
             <GridColumnTitle>History</GridColumnTitle>
@@ -74,6 +60,20 @@ export default function Home() {
             <p className="text-sm">
               Earth hosts more trees than the Milky Way has stars, with estimates of around three
               trillion trees worldwide.
+            </p>
+          </TabsContent>
+        </GridColumn>
+        <GridColumn className="bg-neutral-50">
+          <TabsContent value="chat">
+            <p className="text-sm">
+              Neutron stars are so dense that a teaspoon of their material would weigh about six
+              billion tons on Earth.
+            </p>
+          </TabsContent>
+          <TabsContent value="content">
+            <p className="text-sm">
+              Jupiter's magnetic field is powerful enough to produce auroras larger than our entire
+              planet.
             </p>
           </TabsContent>
         </GridColumn>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
       <GridLayout name="test-layout" scrollable height="calc(100vh - 8rem)">
-        <GridTabs start={2} end={4} height={48}>
+        <GridTabs start={2} end={4}>
           <TabsList>
             <TabsTrigger value="chat">Chat</TabsTrigger>
             <TabsTrigger value="content">Content</TabsTrigger>

--- a/src/components/grid-layout/README.md
+++ b/src/components/grid-layout/README.md
@@ -71,12 +71,24 @@ Use slot components to structure your column content:
 </GridColumn>
 ```
 
+Add a layout-level tab bar spanning specific columns:
+
+```tsx
+<GridLayout name="my-layout" height="100vh">
+  <GridTabs start={2} end={4} height={48}>
+    {/* Tab UI here */}
+  </GridTabs>
+  {/* Columns go here */}
+</GridLayout>
+```
+
 ### Available Slots
 
 - `GridColumnTitle` - Column header title
 - `GridColumnTabs` - Tab navigation area
 - `GridColumnActions` - Action buttons area
 - `GridColumnFooter` - Footer content area
+- `GridTabs` - Layout-level tab bar spanning multiple columns
 
 ## ⚙️ Configuration
 

--- a/src/components/grid-layout/README.md
+++ b/src/components/grid-layout/README.md
@@ -75,12 +75,14 @@ Add a layout-level tab bar spanning specific columns:
 
 ```tsx
 <GridLayout name="my-layout" height="100vh">
-  <GridTabs start={2} end={4} height={48}>
+  <GridTabs start={2} end={4}>
     {/* Tab UI here */}
   </GridTabs>
   {/* Columns go here */}
 </GridLayout>
 ```
+
+The `height` prop is optional and defaults to `HEADER_BLOCK_HEIGHT` (48px).
 
 ### Available Slots
 

--- a/src/components/grid-layout/grid-column-base.tsx
+++ b/src/components/grid-layout/grid-column-base.tsx
@@ -82,7 +82,7 @@ export const GridColumnBase = forwardRef<HTMLDivElement, GridColumnBaseProps>(
           {isCollapsed ? (
             title && (
               <div
-                className="py-12 uppercase flex flex-1 items-center justify-start text-sm"
+                className="px-12 uppercase flex flex-1 items-center justify-start text-sm"
                 style={{ writingMode: "vertical-rl" }}
               >
                 {title}
@@ -109,7 +109,7 @@ export const GridColumnBase = forwardRef<HTMLDivElement, GridColumnBaseProps>(
                     "p-3 flex items-center font-semibold whitespace-nowrap text-lg border-b",
                     BORDER_COLOR,
                     {
-                      "indent-8": isLast && !actions && !tabs,
+                      "indent-8": showToggler && isLast && !actions && !tabs,
                     }
                   )}
                   style={{ height: HEADER_BLOCK_HEIGHT }}

--- a/src/components/grid-layout/grid-column-base.tsx
+++ b/src/components/grid-layout/grid-column-base.tsx
@@ -26,6 +26,7 @@ export const GridColumnBase = forwardRef<HTMLDivElement, GridColumnBaseProps>(
       onResizeStart,
       isResizing = false,
       showScroller = true,
+      style,
     },
     ref
   ) {
@@ -60,6 +61,7 @@ export const GridColumnBase = forwardRef<HTMLDivElement, GridColumnBaseProps>(
             borderClass,
             className
           )}
+          style={style}
         >
           {showToggler && (
             <Button

--- a/src/components/grid-layout/grid-layout.tsx
+++ b/src/components/grid-layout/grid-layout.tsx
@@ -4,30 +4,41 @@ import React, { Children, useRef } from "react";
 
 import { cn } from "@ui/lib/utils";
 
-import type { GridColumn } from "./grid-column";
+import { GridColumn } from "./grid-column";
 import { GridColumnBase } from "./grid-column-base";
 import useGridColumnResizing from "./hooks/use-grid-column-resizing";
 import useGridColumnVisibility from "./hooks/use-grid-column-visibility";
 import type { GridColumnPublicProps } from "./types";
+import type { GridTabsProps } from "./grid-tabs";
+import { GridTabs } from "./grid-tabs";
 
 interface GridLayoutProps {
-  children: Array<React.ReactElement<GridColumnPublicProps, typeof GridColumn>>;
+  children: React.ReactNode;
   height?: string;
   name: string;
   scrollable?: boolean; // allow extra prop used elsewhere
 }
 
 export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps) {
-  const childArray = Children.toArray(children) as Array<
-    React.ReactElement<GridColumnPublicProps, typeof GridColumn>
-  >;
-  const columnCount = childArray.length;
+  const childArray = Children.toArray(children) as Array<React.ReactElement>;
+
+  const tabs = childArray.filter(
+    (child) => child.type === GridTabs
+  ) as Array<React.ReactElement<GridTabsProps, typeof GridTabs>>;
+
+  const columns = childArray.filter(
+    (child) => child.type === GridColumn
+  ) as Array<React.ReactElement<GridColumnPublicProps, typeof GridColumn>>;
+
+  const columnCount = columns.length;
   if (columnCount < 3) {
     throw new Error("GridLayout requires at least three GridColumn children");
   }
   const [visibility, toggle] = useGridColumnVisibility(name, columnCount);
   const [widths, startResize, isResizing] = useGridColumnResizing(name, columnCount, visibility);
   const columnRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  const maxTabHeight = tabs.reduce((max, tab) => Math.max(max, tab.props.height), 0);
 
   const templateColumns = widths
     .map((w) => (w ? `${w}px` : "1fr"))
@@ -43,11 +54,35 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
       style={{
         height,
         gridTemplateColumns: templateColumns,
+        ...(maxTabHeight > 0 && { gridTemplateRows: `${maxTabHeight}px 1fr` }),
       }}
     >
-      {childArray.map((child, index) => {
+      {tabs.map((tab, index) => (
+        <div
+          key={`grid-tabs-${index}`}
+          style={{
+            gridColumn: `${tab.props.start} / ${tab.props.end}`,
+            gridRow: 1,
+            height: `${tab.props.height}px`,
+          }}
+          className="w-full"
+        >
+          {tab.props.children}
+        </div>
+      ))}
+      {columns.map((child, index) => {
         const isLast = index === columnCount - 1;
         const isFirst = index === 0;
+        const columnIndex = index + 1;
+        const isCovered = tabs.some(
+          (tab) =>
+            columnIndex >= tab.props.start && columnIndex < tab.props.end
+        );
+        const gridRow = maxTabHeight
+          ? isCovered
+            ? 2
+            : "1 / span 2"
+          : 1;
         return (
           <GridColumnBase
             key={index}
@@ -63,11 +98,13 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
             showResizer={!isLast && visibility[index] && visibility[index + 1]}
             isResizing={isResizing}
             onResizeStart={(e: React.MouseEvent) => {
-              const startWidth = columnRefs.current[index]?.getBoundingClientRect().width || 0;
+              const startWidth =
+                columnRefs.current[index]?.getBoundingClientRect().width || 0;
               const nextStartWidth =
                 columnRefs.current[index + 1]?.getBoundingClientRect().width || 0;
               startResize(index, startWidth, nextStartWidth, e);
             }}
+            style={{ gridColumn: columnIndex, gridRow }}
           >
             {child.props.children}
           </GridColumnBase>

--- a/src/components/grid-layout/grid-layout.tsx
+++ b/src/components/grid-layout/grid-layout.tsx
@@ -23,18 +23,19 @@ interface GridLayoutProps {
 export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps) {
   const childArray = Children.toArray(children) as Array<React.ReactElement>;
 
-  const tabs = childArray.filter(
-    (child) => child.type === GridTabs
-  ) as Array<React.ReactElement<GridTabsProps, typeof GridTabs>>;
+  const tabs = childArray.filter((child) => child.type === GridTabs) as Array<
+    React.ReactElement<GridTabsProps, typeof GridTabs>
+  >;
 
-  const columns = childArray.filter(
-    (child) => child.type === GridColumn
-  ) as Array<React.ReactElement<GridColumnPublicProps, typeof GridColumn>>;
+  const columns = childArray.filter((child) => child.type === GridColumn) as Array<
+    React.ReactElement<GridColumnPublicProps, typeof GridColumn>
+  >;
 
   const columnCount = columns.length;
   if (columnCount < 3) {
     throw new Error("GridLayout requires at least three GridColumn children");
   }
+
   const [visibility, toggle] = useGridColumnVisibility(name, columnCount);
   const [widths, startResize, isResizing] = useGridColumnResizing(name, columnCount, visibility);
   const columnRefs = useRef<Array<HTMLDivElement | null>>([]);
@@ -68,9 +69,9 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
           style={{
             gridColumn: `${tab.props.start} / ${tab.props.end}`,
             gridRow: 1,
-            height: `${(tab.props.height ?? HEADER_BLOCK_HEIGHT)}px`,
+            height: `${tab.props.height ?? HEADER_BLOCK_HEIGHT}px`,
           }}
-          className={cn("w-full border-b", BORDER_COLOR)}
+          className={cn("w-full p-3 border-b border-l border-r", BORDER_COLOR)}
         >
           {tab.props.children}
         </div>
@@ -81,16 +82,11 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
         const columnIndex = index + 1;
         // Does this column fall beneath any tab's column span?
         const isCovered = tabs.some(
-          (tab) =>
-            columnIndex >= tab.props.start && columnIndex < tab.props.end
+          (tab) => columnIndex >= tab.props.start && columnIndex < tab.props.end
         );
         // Covered columns start on row 2 under the tabs. Uncovered columns span both
         // rows so their content fills the full height whether tabs exist or not.
-        const gridRow = maxTabHeight
-          ? isCovered
-            ? 2
-            : "1 / span 2"
-          : 1;
+        const gridRow = maxTabHeight ? (isCovered ? 2 : "1 / span 2") : 1;
         return (
           <GridColumnBase
             key={index}
@@ -106,8 +102,7 @@ export function GridLayout({ children, name, height = "100vh" }: GridLayoutProps
             showResizer={!isLast && visibility[index] && visibility[index + 1]}
             isResizing={isResizing}
             onResizeStart={(e: React.MouseEvent) => {
-              const startWidth =
-                columnRefs.current[index]?.getBoundingClientRect().width || 0;
+              const startWidth = columnRefs.current[index]?.getBoundingClientRect().width || 0;
               const nextStartWidth =
                 columnRefs.current[index + 1]?.getBoundingClientRect().width || 0;
               startResize(index, startWidth, nextStartWidth, e);

--- a/src/components/grid-layout/grid-tabs.tsx
+++ b/src/components/grid-layout/grid-tabs.tsx
@@ -7,8 +7,8 @@ export interface GridTabsProps {
   start: number;
   /** Exclusive ending column index */
   end: number;
-  /** Height of the tab bar in pixels */
-  height: number;
+  /** Height of the tab bar in pixels. Defaults to HEADER_BLOCK_HEIGHT. */
+  height?: number;
   /** Tab UI content */
   children: ReactNode;
 }

--- a/src/components/grid-layout/grid-tabs.tsx
+++ b/src/components/grid-layout/grid-tabs.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export interface GridTabsProps {
+  /** Inclusive starting column index (1-based) */
+  start: number;
+  /** Exclusive ending column index */
+  end: number;
+  /** Height of the tab bar in pixels */
+  height: number;
+  /** Tab UI content */
+  children: ReactNode;
+}
+
+// This component acts as a marker for layout-level tabs. It is rendered by GridLayout.
+export function GridTabs(_props: GridTabsProps) {
+  return null;
+}
+

--- a/src/components/grid-layout/index.ts
+++ b/src/components/grid-layout/index.ts
@@ -1,2 +1,3 @@
 export * from "./grid-layout";
 export * from "./grid-column";
+export * from "./grid-tabs";

--- a/src/components/grid-layout/types.ts
+++ b/src/components/grid-layout/types.ts
@@ -1,3 +1,5 @@
+import type React from "react";
+
 export interface GridColumnPublicProps {
   /** Display the column resize handle */
   showResizer?: boolean;
@@ -24,4 +26,6 @@ export interface GridColumnBaseProps extends GridColumnPublicProps {
   onResizeStart?: (e: React.MouseEvent) => void;
   /** Is the column currently being resized? */
   isResizing?: boolean;
+  /** Additional style properties */
+  style?: React.CSSProperties;
 }


### PR DESCRIPTION
## Summary
- add `GridTabs` marker component for layout-level tab bars
- update `GridLayout` to render grid-spanning tabs and shift columns accordingly
- allow `GridColumnBase` to accept style for grid placement and document usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6894b47daf788321ae17d7ea64398dd3